### PR TITLE
Adding targetOs option to define _target_os in rpm spec

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -19,6 +19,7 @@ module.exports = function(files, options) {
   var b = [];
 
   b.push('%define   _topdir ' + path.resolve(options.tempDir));
+  b.push('%define   _target_os ' + options.targetOs);
   b.push('');
   b.push('Name: ' + options.name);
   b.push('Version: ' + options.version);


### PR DESCRIPTION
Signed-off-by Junil Kim <logyourself@gmail.com>